### PR TITLE
Update `orca_alert_finding` ingestion to reduce volume and disk usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.6.1 - 2022-07-27
+
+### Changed
+
+- Removed ingestion of information alerts
+- Disable storing `orca_alert_finding` on file system. Orca alert findings can
+  be super high volume. We don't iterate this data in later steps, so we can
+  safely disable storing the data on the file system to save disk space.
+
 ## 1.6.0 - 2022-07-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-orca",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A JupiterOne Integration for ingesting data for the Orca",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -392,7 +392,6 @@ export class APIClient {
     iteratee: ResourceIteratee<OrcaAlert>,
   ): Promise<void> {
     await this.iterateViaBulkDownload<OrcaAlert>(iteratee, '/query/alerts', {
-      show_informational_alerts: true,
       dsl_filter: {
         filter: [
           {

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -110,6 +110,9 @@ export const Entities: Record<
     resourceName: 'Alert',
     _type: 'orca_finding_alert',
     _class: ['Finding'],
+    indexMetadata: {
+      enabled: false,
+    },
     schema: {
       properties: {
         name: { type: 'string' },


### PR DESCRIPTION
# Description

- Removed ingestion of information alerts
- Disable storing `orca_alert_finding` on file system. Orca alert findings can
  be super high volume. We don't iterate this data in later steps, so we can
  safely disable storing the data on the file system to save disk space.
## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
